### PR TITLE
fix(service endpoint): Added region handling for creating correct streaming endpoint from region

### DIFF
--- a/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
+++ b/aws-predictions/src/main/java/com/amplifyframework/predictions/aws/service/RunFaceLivenessSession.kt
@@ -47,7 +47,7 @@ internal class RunFaceLivenessSession(
     onError: Consumer<PredictionsException>
 ) {
 
-    private val livenessEndpoint = "wss://streaming-rekognition.${sessionInformation.region}.amazonaws.com:443"
+    private val livenessEndpoint = getStreamingEndpointForRegion(sessionInformation.region)
 
     private val livenessWebSocket = LivenessWebSocket(
         credentialsProvider = credentialsProvider,
@@ -182,5 +182,18 @@ internal class RunFaceLivenessSession(
     private fun stopLivenessSession(reasonCode: Int?) {
         livenessWebSocket.clientStoppedSession = true
         reasonCode?.let { livenessWebSocket.destroy(it) } ?: livenessWebSocket.destroy()
+    }
+
+    private fun getStreamingEndpointForRegion(region: String): String {
+        val baseDomain = when {
+            region.startsWith("us-isof", ignoreCase = true) -> ISO_PARTITION_BASE_DOMAIN
+            else -> DEFAULT_BASE_DOMAIN
+        }
+        return "wss://streaming-rekognition.${region}.${baseDomain}:443"
+    }
+
+    companion object {
+        private const val ISO_PARTITION_BASE_DOMAIN = "csp.hci.ic.gov"
+        private const val DEFAULT_BASE_DOMAIN = "amazonaws.com"
     }
 }


### PR DESCRIPTION
- [x] PR title and description conform to [Pull Request](https://github.com/aws-amplify/amplify-android/blob/main/CONTRIBUTING.md#pull-request-guidelines) guidelines.

*Issue #, if available:*

*Description of changes:*
We need to construct the correct streaming endpoint with correct base domain depending on the regions. Not all region belong to commercial partition so the base domain becomes different. We can keep adding new regions in this check to get the desired base domain in future. 

*How did you test these changes?*
Tested through a isolated main program.

*Documentation update required?*
- [x] No
- [ ] Yes (Please include a PR link for the documentation update)

*General Checklist*
- [ ] Added Unit Tests
- [ ] Added Integration Tests
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
